### PR TITLE
Show more info for 5xx errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/bole.js
+++ b/bole.js
@@ -17,6 +17,27 @@ function stackToString (e) {
   return s
 }
 
+function getUrl(err) {
+  if (err.options && err.options.url)
+    return err.options.url
+
+  if (err.options && err.options.uri)
+    return err.options.uri
+
+  return undefined;
+}
+
+function getMessage(err) {
+  var url, error, message
+  url = getUrl(err)
+  error = err.error && err.error.error ? err.error.error : undefined
+  message = err.message
+  if (error)
+    message += ' ' + error
+  if (url)
+    message += ' for ' + url
+  return message
+}
 
 function levelLogger (level, name) {
   return function (inp) {
@@ -42,7 +63,7 @@ function levelLogger (level, name) {
 
       out.err = {
           name    : inp.name
-        , message : inp.options && inp.options.url ? inp.message + ' for ' + inp.options.url : inp.message
+        , message : getMessage(inp)
         , code    : inp.statusCode
         , stack   : ''
       }
@@ -52,7 +73,7 @@ function levelLogger (level, name) {
 
       out.err = {
           name    : inp.name
-        , message : inp.options && inp.options.uri ? inp.message + ' for ' + inp.options.uri : inp.message
+        , message : getMessage(inp)
         , code    : inp.error && inp.error.code ? inp.error.code : ''
         , stack   : ''
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bole",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A tiny JSON logger",
   "main": "bole.js",
   "scripts": {


### PR DESCRIPTION
#### before:

```
2016-03-14T12:31:35.618+00:00 warn [collector:post-results]: Retry 1 failed for result set for device 55a6accbb8c18ce214e58518 at 1457958604481 - StatusCodeError: 500 - [object Object]
```
#### after:

```
2016-03-14T12:35:25.153+00:00 warn [collector:post-results]: Retry 1 failed for result set for device 55a6accbb8c18ce214e58518 at 1457958845093 - StatusCodeError: 500 - [object Object] request entity too large for http://localhost:8000/api/v1/metrics/devices/55a6accbb8c18ce214e58518/snmp/batch
```
